### PR TITLE
Enhancing the VSCode Developer Experience

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -46,7 +46,4 @@
             ]
         }
     },
-    "runArgs": [
-        "--network=host"
-    ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ junit.xml
 # Home Assistant configuration
 config/*
 !config/configuration.yaml
+
+# Integration configuration
+/custom_components/wiser_by_feller/aiowiserbyfeller

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,88 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Home Assistant",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "homeassistant",
+      "justMyCode": false,
+      "args": ["--debug", "-c", "config"],
+      "preLaunchTask": ""
+    },
+    {
+      "name": "Home Assistant (local api)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "homeassistant",
+      "justMyCode": false,
+      "args": ["--debug", "-c", "config", "--skip-pip"],
+      "preLaunchTask": "Compile English translations",
+      "env": {
+        "PYTHONPATH": "${PYTHONPATH}:${workspaceFolder}/custom_components/wiser_by_feller"
+      }
+    },
+    {
+      "name": "Home Assistant (skip pip)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "homeassistant",
+      "justMyCode": false,
+      "args": ["--debug", "-c", "config", "--skip-pip"],
+      "preLaunchTask": "Compile English translations"
+    },
+    /* {
+      "name": "Home Assistant: Changed tests",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "justMyCode": false,
+      "args": ["--picked"]
+    },
+    {
+      "name": "Home Assistant: Debug Current Test File",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "console": "integratedTerminal",
+      "args": ["-vv", "${file}"]
+    },
+    {
+      // Debug by attaching to local Home Assistant server using Remote Python Debugger.
+      // See https://www.home-assistant.io/integrations/debugpy/
+      "name": "Home Assistant: Attach Local",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {
+        "port": 5678,
+        "host": "localhost"
+      },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}",
+          "remoteRoot": "."
+        }
+      ]
+    },
+    {
+      // Debug by attaching to remote Home Assistant server using Remote Python Debugger.
+      // See https://www.home-assistant.io/integrations/debugpy/
+      "name": "Home Assistant: Attach Remote",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {
+        "port": 5678,
+        "host": "homeassistant.local"
+      },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}",
+          "remoteRoot": "/usr/src/homeassistant"
+        }
+      ]
+    } */
+  ]
+}

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,6 +1,10 @@
 # https://www.home-assistant.io/integrations/default_config/
 default_config:
 
+go2rtc:
+  url: http://localhost:1984 # Removes errors in logs
+
+
 # https://www.home-assistant.io/integrations/homeassistant/
 homeassistant:
   debug: true
@@ -11,6 +15,7 @@ logger:
   logs:
     custom_components.wiser_by_feller: debug
 
+# Adds Log Viewer to the sidebar
 panel_custom:
   - name: logs
     sidebar_title: Logs

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -10,3 +10,14 @@ logger:
   default: info
   logs:
     custom_components.wiser_by_feller: debug
+
+panel_custom:
+  - name: logs
+    sidebar_title: Logs
+    sidebar_icon: mdi:math-log
+    url_path: config/logs
+    js_url: /api/hassio/app/entrypoint.js
+    embed_iframe: true
+    require_admin: true
+    config:
+      ingress: core_configurator


### PR DESCRIPTION
VSCode Launch Config

- **Home Assistant**
- **Home Assistant (local api)** requires a copy of the api in `${workspaceFolder}/custom_components/wiser_by_feller`
- **Home Assistant (skip pip)**

GitIgnore

- Ignores the local copy of the api in `${workspaceFolder}/custom_components/wiser_by_feller/aiowiserbyfeller`

DevContainer
- removed runargs as that breaks debugger, at least in WSL environment.

Home Assistant Config

- Adds an entry for the logs to the Home Assistant side panel