### PR TITLE
WebSocket: Close connection on failure and add reconnection logic

### DIFF
--- a/custom_components/wiser_by_feller/__init__.py
+++ b/custom_components/wiser_by_feller/__init__.py
@@ -55,6 +55,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    coordinator = hass.data[DOMAIN].get(entry.entry_id)
+    if coordinator is not None:
+        await coordinator._ws_close()
+
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
 

--- a/custom_components/wiser_by_feller/coordinator.py
+++ b/custom_components/wiser_by_feller/coordinator.py
@@ -266,6 +266,15 @@ class WiserCoordinator(DataUpdateCoordinator):
 
             _LOGGER.debug("Successfully updated data from µGateway.")
 
+            # Reconnect WebSocket if it has died
+            if self._ws._idle:
+                _LOGGER.warning(
+                    "WebSocket connection to µGateway is idle/disconnected. Reconnecting..."
+                )
+                await self._ws_close()
+                self._ws._errcount = 0
+                self._ws.init()
+
         except asyncio.TimeoutError as err:
             raise UpdateFailed("Timeout while fetching data from µGateway") from err
         except (AuthorizationFailed, UnauthorizedUser) as err:
@@ -275,11 +284,21 @@ class WiserCoordinator(DataUpdateCoordinator):
         except UnsuccessfulRequest as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
+    async def _ws_close(self) -> None:
+        """Close the WebSocket connection if it exists."""
+        if self._ws._ws is not None:
+            try:
+                await self._ws._ws.close()
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("Error closing WebSocket connection, ignoring")
+            self._ws._ws = None
+        self._ws._watchdog.cancel()
+
     def ws_init(self) -> None:
         """Set up websocket with µGateway to receive load updates."""
         self._ws.subscribe(self.ws_update_data)
         self._ws.init()
-        # TODO: Check connection / reconnect -> Watchdog
+        # WebSocket reconnection is handled in _async_update_data()
 
     def ws_update_data(self, data: dict) -> None:
         """Process websocket data update."""


### PR DESCRIPTION
## Summary
Fixes #57

- **Add `_ws_close()` method** for safe WebSocket teardown — closes the underlying connection, clears the reference, and cancels the watchdog timer
- **Close WebSocket on integration unload** in `async_unload_entry()` to prevent orphan connections when HA restarts or the integration is removed
- **Auto-reconnect idle WebSocket** during coordinator updates — detects when `_idle=True` (after 10 failed connection attempts) and reinitializes the connection

Without this fix, failed WebSocket connections are never closed, accumulating on the µGateway until it runs out of memory and becomes unresponsive. Restarting HA alone doesn't help since the OS-level connections remain open.

## Test plan
- [x] Simulated gateway outage via `iptables -A OUTPUT -d <gateway-ip> -j DROP`, verified reconnection after unblock
- [x] Verified zero `TypeError` or WebSocket errors over 12+ hours of normal operation
- [x] Confirmed proper cleanup on integration unload

🤖 Generated with [Claude Code](https://claude.com/claude-code)