### PR TITLE
Improve quality scale rating

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,10 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements.test.txt ]; then pip install -r requirements.test.txt; fi
+      - name: Install mypy
+        run: pip install mypy
+      - name: Run mypy
+        run: mypy custom_components/wiser_by_feller/
       - name: Run tests
         run: pytest tests/ --junitxml=junit.xml --cov=custom_components/wiser_by_feller --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html
       - name: Archive code coverage results

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Wiser scenes are integrated as native Home Assistant scenes, allowing to trigger
 The integration listens to state changes via a Websocket, leading to near-instant updates in Home Assistant
 
 ### 🚨 Status LEDs
-Wiser by Feller devices have customizable status LEDs that can indicate load states or system status. The integration supports two ways to control these LEDs. For detailed information on both methods, including examples and advanced features, see the [LED Control documentation](docs/led_control.md).
+Wiser by Feller devices have customizable status LEDs that can indicate load states or system status. The integration supports two ways to control these LEDs. For detailed information on both methods, including examples and advanced features, see the [LED Control documentation](docs/led-control.md).
 
 ### 🕹️ System Flag
 Already configured system flags appear as switches in Home Assistant. Unfortunately currently there is no way to configure them other than via API. An integrated management of flags is planned (See #20).

--- a/custom_components/wiser_by_feller/__init__.py
+++ b/custom_components/wiser_by_feller/__init__.py
@@ -88,16 +88,26 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Wiser by Feller integration."""
 
     async def handle_status_light(call: ServiceCall) -> None:
+        device_id = call.data["device"]
         device_registry = dr.async_get(hass)
-        device = device_registry.async_get(call.data["device"])
+        device = device_registry.async_get(device_id)
         if device is None:
-            return
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+                translation_placeholders={"device_id": device_id},
+            )
         for entry_id in device.config_entries:
             entry = hass.config_entries.async_get_entry(entry_id)
             if entry and entry.domain == DOMAIN and entry.runtime_data is not None:
                 coordinator: WiserCoordinator = entry.runtime_data
                 await coordinator.async_set_status_light(call)
                 return
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="device_not_found",
+            translation_placeholders={"device_id": device_id},
+        )
 
     hass.services.async_register(DOMAIN, SERVICE_STATUS_LIGHT, handle_status_light)
     return True

--- a/custom_components/wiser_by_feller/__init__.py
+++ b/custom_components/wiser_by_feller/__init__.py
@@ -263,7 +263,18 @@ async def async_remove_stale_devices(
     entry: ConfigEntry,
     coord: WiserCoordinator,
 ) -> None:
-    """Remove device registry entries no longer present in the Wiser gateway."""
+    """Remove device registry entries no longer present in the Wiser gateway.
+
+    Only runs when the coordinator holds a complete picture of the loads and
+    devices. If the gateway returned partial data (e.g. a transient failure or
+    the "Allow missing µGateway data" option), the expected set would be
+    incomplete, and we could wrongly delete valid devices together with their
+    entities, history and automations. In that case we skip cleanup entirely.
+    """
+    if coord.loads is None or coord.devices is None:
+        _LOGGER.debug("Skipping stale device cleanup: coordinator data is incomplete.")
+        return
+
     device_registry = dr.async_get(hass)
 
     expected: set[str] = set()
@@ -273,10 +284,10 @@ async def async_remove_stale_devices(
     else:
         expected.add(entry.title)
 
-    for load in (coord.loads or {}).values():
+    for load in coord.loads.values():
         expected.add(f"{load.device}_{load.channel}")
 
-    for device in (coord.devices or {}).values():
+    for device in coord.devices.values():
         expected.add(device.id)
 
     for hvac_group in (coord.hvac_groups or {}).values():
@@ -286,13 +297,18 @@ async def async_remove_stale_devices(
     for device_entry in dr.async_entries_for_config_entry(
         device_registry, entry.entry_id
     ):
-        for domain, identifier in device_entry.identifiers:
-            if domain == DOMAIN and identifier not in expected:
-                _LOGGER.debug(
-                    "Removing stale device %s (%s)", device_entry.name, identifier
-                )
-                device_registry.async_remove_device(device_entry.id)
-                break
+        if any(
+            domain == DOMAIN and identifier not in expected
+            for domain, identifier in device_entry.identifiers
+        ):
+            _LOGGER.debug(
+                "Detaching stale device %s from config entry", device_entry.name
+            )
+            # Detach this config entry rather than deleting outright: HA removes
+            # the device only if no other config entry still references it.
+            device_registry.async_update_device(
+                device_entry.id, remove_config_entry_id=entry.entry_id
+            )
 
 
 async def async_setup_gateway(

--- a/custom_components/wiser_by_feller/__init__.py
+++ b/custom_components/wiser_by_feller/__init__.py
@@ -128,6 +128,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await wiser_coordinator.async_config_entry_first_refresh()
     await async_setup_gateway(hass, entry, wiser_coordinator)
+    await async_remove_stale_devices(hass, entry, wiser_coordinator)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def async_set_button_led_override(call: ServiceCall) -> None:
@@ -255,6 +256,43 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.services.async_remove(DOMAIN, SERVICE_FIND_BUTTON)
 
     return unload_ok
+
+
+async def async_remove_stale_devices(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coord: WiserCoordinator,
+) -> None:
+    """Remove device registry entries no longer present in the Wiser gateway."""
+    device_registry = dr.async_get(hass)
+
+    expected: set[str] = set()
+
+    if coord.gateway is not None:
+        expected.add(coord.gateway.combined_serial_number)
+    else:
+        expected.add(entry.title)
+
+    for load in (coord.loads or {}).values():
+        expected.add(f"{load.device}_{load.channel}")
+
+    for device in (coord.devices or {}).values():
+        expected.add(device.id)
+
+    for hvac_group in (coord.hvac_groups or {}).values():
+        if hvac_group.thermostat_ref is not None:
+            expected.add(f"{hvac_group.thermostat_ref.unprefixed_address}_hvac_group")
+
+    for device_entry in dr.async_entries_for_config_entry(
+        device_registry, entry.entry_id
+    ):
+        for domain, identifier in device_entry.identifiers:
+            if domain == DOMAIN and identifier not in expected:
+                _LOGGER.debug(
+                    "Removing stale device %s (%s)", device_entry.name, identifier
+                )
+                device_registry.async_remove_device(device_entry.id)
+                break
 
 
 async def async_setup_gateway(

--- a/custom_components/wiser_by_feller/__init__.py
+++ b/custom_components/wiser_by_feller/__init__.py
@@ -19,7 +19,6 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.translation import async_get_translations
 from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
 
@@ -197,18 +196,17 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         device = result.get("device")
         channel = result.get("channel")
 
-        note = None
         fields: dict = {"room_name": None, "device_name": None, "scene_name": None}
 
         if button_id is not None:
             fields = coordinator.resolve_managed_button_fields(button_id)
         elif device is not None:
-            translations = await async_get_translations(
-                hass, hass.config.language, "services", [DOMAIN]
-            )
-            note = translations.get(
-                f"component.{DOMAIN}.services.find_button.note_unmanaged_button",
-                "This button is unmanaged. See docs for more information.",
+            # The button exists physically but isn't managed by the gateway, so
+            # there is nothing to control. Surface this as a validation error
+            # pointing the user to the documentation.
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="unmanaged_button",
             )
 
         parts = [
@@ -233,8 +231,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             lines.append(f"Device: `{device}`")
         if channel is not None:
             lines.append(f"Channel: `{channel}`")
-        if note is not None:
-            lines.append(f"_{note}_")
 
         async_create_notification(
             hass,
@@ -250,7 +246,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             "room_name": fields["room_name"],
             "device_name": fields["device_name"],
             "scene_name": fields["scene_name"],
-            "note": note,
         }
 
     hass.services.async_register(DOMAIN, SERVICE_STATUS_LIGHT, handle_status_light)

--- a/custom_components/wiser_by_feller/__init__.py
+++ b/custom_components/wiser_by_feller/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.typing import ConfigType
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.translation import async_get_translations
 import voluptuous as vol
@@ -83,6 +84,25 @@ CLEAR_BUTTON_LED_OVERRIDE_SCHEMA = vol.Schema(
 )
 
 
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Wiser by Feller integration."""
+
+    async def handle_status_light(call: ServiceCall) -> None:
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get(call.data["device"])
+        if device is None:
+            return
+        for entry_id in device.config_entries:
+            entry = hass.config_entries.async_get_entry(entry_id)
+            if entry and entry.domain == DOMAIN and entry.runtime_data is not None:
+                coordinator: WiserCoordinator = entry.runtime_data
+                await coordinator.async_set_status_light(call)
+                return
+
+    hass.services.async_register(DOMAIN, SERVICE_STATUS_LIGHT, handle_status_light)
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Wiser by Feller from a config entry."""
     session = async_get_clientsession(hass)
@@ -99,10 +119,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await wiser_coordinator.async_config_entry_first_refresh()
     await async_setup_gateway(hass, entry, wiser_coordinator)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    hass.services.async_register(
-        DOMAIN, SERVICE_STATUS_LIGHT, wiser_coordinator.async_set_status_light
-    )
 
     async def async_set_button_led_override(call: ServiceCall) -> None:
         """Set button LED override."""
@@ -224,7 +240,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.ws_close()
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.services.async_remove(DOMAIN, SERVICE_STATUS_LIGHT)
         hass.services.async_remove(DOMAIN, SERVICE_SET_BUTTON_LED_OVERRIDE)
         hass.services.async_remove(DOMAIN, SERVICE_CLEAR_BUTTON_LED_OVERRIDE)
         hass.services.async_remove(DOMAIN, SERVICE_FIND_BUTTON)

--- a/custom_components/wiser_by_feller/__init__.py
+++ b/custom_components/wiser_by_feller/__init__.py
@@ -18,9 +18,9 @@ from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.typing import ConfigType
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.translation import async_get_translations
+from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
 
 from .const import DOMAIN, LED_OFF_COLOR, MANUFACTURER
@@ -62,7 +62,7 @@ def validate_rgb_color(value: Any) -> tuple[int, int, int]:
     if any(color < 0 or color > 255 for color in rgb):
         raise vol.Invalid("RGB values must be between 0 and 255")
 
-    return rgb
+    return rgb[0], rgb[1], rgb[2]
 
 
 SET_BUTTON_LED_OVERRIDE_SCHEMA = vol.Schema(
@@ -301,6 +301,7 @@ async def async_setup_gateway(
     coord: WiserCoordinator,
 ) -> None:
     """Set up the gateway device."""
+    assert coord.config_entry is not None
     if coord.gateway is None:
         _LOGGER.warning(
             "The gateway device is not recognized in the coordinator, which can happen if option "
@@ -314,6 +315,7 @@ async def async_setup_gateway(
         sw_version = None
         hw_version = None
     else:
+        assert coord.gateway_info is not None
         gateway_identifier = coord.gateway.combined_serial_number
         generation = parse_wiser_device_ref_c(coord.gateway.c["comm_ref"])["generation"]
         name = f"{coord.config_entry.title} µGateway"
@@ -324,6 +326,9 @@ async def async_setup_gateway(
     area = None
     for output in coord.gateway.outputs if coord.gateway is not None else []:
         if "load" not in output:
+            continue
+
+        if coord.loads is None or coord.rooms is None:
             continue
 
         load = coord.loads.get(output["load"])

--- a/custom_components/wiser_by_feller/__init__.py
+++ b/custom_components/wiser_by_feller/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.components.light import ATTR_RGB_COLOR
 from homeassistant.components.persistent_notification import (
     async_create as async_create_notification,
 )
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
@@ -46,6 +46,7 @@ SERVICE_FIND_BUTTON = "find_button"
 ATTR_BUTTON_ID = "button_id"
 ATTR_LED_INDEX = "led_index"
 ATTR_EFFECT = "effect"
+ATTR_CONFIG_ENTRY_ID = "config_entry_id"
 
 
 def rgb_tuple_to_hex(rgb: tuple[int, int, int]) -> str:
@@ -67,6 +68,7 @@ def validate_rgb_color(value: Any) -> tuple[int, int, int]:
 
 SET_BUTTON_LED_OVERRIDE_SCHEMA = vol.Schema(
     {
+        vol.Optional(ATTR_CONFIG_ENTRY_ID): cv.string,
         vol.Required(ATTR_BUTTON_ID): cv.positive_int,
         vol.Required(ATTR_LED_INDEX, default="0"): vol.In(["0", "1"]),
         vol.Required(ATTR_RGB_COLOR, default=(0, 255, 0)): validate_rgb_color,
@@ -78,14 +80,63 @@ SET_BUTTON_LED_OVERRIDE_SCHEMA = vol.Schema(
 
 CLEAR_BUTTON_LED_OVERRIDE_SCHEMA = vol.Schema(
     {
+        vol.Optional(ATTR_CONFIG_ENTRY_ID): cv.string,
         vol.Required(ATTR_BUTTON_ID): cv.positive_int,
         vol.Required(ATTR_LED_INDEX, default="0"): vol.In(["0", "1"]),
     }
 )
 
+FIND_BUTTON_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_CONFIG_ENTRY_ID): cv.string,
+    }
+)
+
+
+def _resolve_coordinator(
+    hass: HomeAssistant, entry_id: str | None = None
+) -> WiserCoordinator:
+    """Resolve the coordinator for a gateway-wide button service.
+
+    Button ids are unique only per µGateway, so the caller selects the gateway
+    via its config entry. When exactly one gateway is loaded the selection is
+    optional and that gateway is used; with several loaded, one must be chosen.
+    """
+    loaded = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.state is ConfigEntryState.LOADED and entry.runtime_data is not None
+    ]
+
+    if entry_id is not None:
+        for entry in loaded:
+            if entry.entry_id == entry_id:
+                return entry.runtime_data
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="no_gateway_loaded",
+        )
+
+    if not loaded:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="no_gateway_loaded",
+        )
+    if len(loaded) > 1:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="specify_gateway",
+        )
+    return loaded[0].runtime_data
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Wiser by Feller integration."""
+    """Set up the Wiser by Feller integration.
+
+    All service actions are registered here, once per integration load, so they
+    exist even when no config entry is loaded and are never re-registered or
+    removed per entry.
+    """
 
     async def handle_status_light(call: ServiceCall) -> None:
         device_id = call.data["device"]
@@ -109,32 +160,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             translation_placeholders={"device_id": device_id},
         )
 
-    hass.services.async_register(DOMAIN, SERVICE_STATUS_LIGHT, handle_status_light)
-    return True
-
-
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Wiser by Feller from a config entry."""
-    session = async_get_clientsession(hass)
-    auth = Auth(session, entry.data["host"], token=entry.data["token"])
-    api = WiserByFellerAPI(auth)
-
-    wiser_coordinator = WiserCoordinator(
-        hass, api, entry.data["host"], entry.data["token"], entry.options
-    )
-    wiser_coordinator.ws_init()
-
-    entry.runtime_data = wiser_coordinator
-
-    await wiser_coordinator.async_config_entry_first_refresh()
-    await async_setup_gateway(hass, entry, wiser_coordinator)
-    await async_remove_stale_devices(hass, entry, wiser_coordinator)
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
     async def async_set_button_led_override(call: ServiceCall) -> None:
         """Set button LED override."""
+        coordinator = _resolve_coordinator(hass, call.data.get(ATTR_CONFIG_ENTRY_ID))
         try:
-            await wiser_coordinator.api.async_set_button_led(
+            await coordinator.api.async_set_button_led(
                 button_id=call.data[ATTR_BUTTON_ID],
                 led_index=int(call.data[ATTR_LED_INDEX]),
                 on=True,
@@ -146,8 +176,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_clear_button_led_override(call: ServiceCall) -> None:
         """Clear button LED override."""
+        coordinator = _resolve_coordinator(hass, call.data.get(ATTR_CONFIG_ENTRY_ID))
         try:
-            await wiser_coordinator.api.async_set_button_led(
+            await coordinator.api.async_set_button_led(
                 button_id=call.data[ATTR_BUTTON_ID],
                 led_index=int(call.data[ATTR_LED_INDEX]),
                 on=False,
@@ -159,7 +190,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_find_button_service(call: ServiceCall) -> dict[str, Any]:
         """Find a physical button by activating find-me mode."""
-        result = await wiser_coordinator.async_find_button()
+        coordinator = _resolve_coordinator(hass, call.data.get(ATTR_CONFIG_ENTRY_ID))
+        result = await coordinator.async_find_button()
 
         button_id = result.get("button_id")
         device = result.get("device")
@@ -169,7 +201,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         fields: dict = {"room_name": None, "device_name": None, "scene_name": None}
 
         if button_id is not None:
-            fields = wiser_coordinator.resolve_managed_button_fields(button_id)
+            fields = coordinator.resolve_managed_button_fields(button_id)
         elif device is not None:
             translations = await async_get_translations(
                 hass, hass.config.language, "services", [DOMAIN]
@@ -221,26 +253,46 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "note": note,
         }
 
+    hass.services.async_register(DOMAIN, SERVICE_STATUS_LIGHT, handle_status_light)
     hass.services.async_register(
         DOMAIN,
         SERVICE_SET_BUTTON_LED_OVERRIDE,
         async_set_button_led_override,
         schema=SET_BUTTON_LED_OVERRIDE_SCHEMA,
     )
-
     hass.services.async_register(
         DOMAIN,
         SERVICE_CLEAR_BUTTON_LED_OVERRIDE,
         async_clear_button_led_override,
         schema=CLEAR_BUTTON_LED_OVERRIDE_SCHEMA,
     )
-
     hass.services.async_register(
         DOMAIN,
         SERVICE_FIND_BUTTON,
         async_find_button_service,
+        schema=FIND_BUTTON_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Wiser by Feller from a config entry."""
+    session = async_get_clientsession(hass)
+    auth = Auth(session, entry.data["host"], token=entry.data["token"])
+    api = WiserByFellerAPI(auth)
+
+    wiser_coordinator = WiserCoordinator(
+        hass, api, entry.data["host"], entry.data["token"], entry.options
+    )
+    wiser_coordinator.ws_init()
+
+    entry.runtime_data = wiser_coordinator
+
+    await wiser_coordinator.async_config_entry_first_refresh()
+    await async_setup_gateway(hass, entry, wiser_coordinator)
+    await async_remove_stale_devices(hass, entry, wiser_coordinator)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
@@ -249,13 +301,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     coordinator: WiserCoordinator = entry.runtime_data
     await coordinator.ws_close()
-
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.services.async_remove(DOMAIN, SERVICE_SET_BUTTON_LED_OVERRIDE)
-        hass.services.async_remove(DOMAIN, SERVICE_CLEAR_BUTTON_LED_OVERRIDE)
-        hass.services.async_remove(DOMAIN, SERVICE_FIND_BUTTON)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_remove_stale_devices(

--- a/custom_components/wiser_by_feller/button.py
+++ b/custom_components/wiser_by_feller/button.py
@@ -31,7 +31,11 @@ async def async_setup_entry(
     """Set up Wiser button entities."""
     coordinator: WiserCoordinator = entry.runtime_data
 
-    entities = []
+    assert coordinator.loads is not None
+    assert coordinator.states is not None
+    assert coordinator.devices is not None
+    assert coordinator.rooms is not None
+    entities: list[WiserEntity] = []
     for load in coordinator.loads.values():
         load.raw_state = coordinator.states[load.id]
         device = coordinator.devices[load.device]
@@ -57,7 +61,7 @@ async def async_setup_entry(
         if group.thermostat_ref is None:
             continue
 
-        thermostat = coordinator.devices[group.thermostat_ref.unprefixed_address]
+        thermostat = coordinator.devices.get(group.thermostat_ref.unprefixed_address)
 
         if thermostat is None:
             continue
@@ -75,6 +79,8 @@ class WiserPingEntity(WiserEntity, ButtonEntity):
     These allow a load or device to be pinged, resulting in a flashing button
     illumination on the targeted device. This helps to identify devices.
     """
+
+    _device: Device
 
     def __init__(
         self,
@@ -114,6 +120,8 @@ class WiserClimatePingEntity(WiserHvacGroupDeviceEntity, WiserEntity, ButtonEnti
     resulting in a flashing button illumination on the targeted device.
     """
 
+    _hvac_group: HvacGroup
+
     def __init__(
         self,
         coordinator: WiserCoordinator,
@@ -142,6 +150,7 @@ class WiserClimatePingEntity(WiserHvacGroupDeviceEntity, WiserEntity, ButtonEnti
 
     async def async_press(self, **kwargs: Any) -> None:
         """Ping the load or device to illuminate the button."""
+        assert self.coordinator.loads is not None
         for load_id in self._hvac_group.loads:
             await self.coordinator.loads[load_id].async_ping(
                 10000, BlinkPattern.RAMP, HA_BLUE
@@ -155,6 +164,8 @@ class WiserImpulseEntity(WiserEntity, ButtonEntity):
 
     These are OnOff loads that have been configured for impulse switching.
     """
+
+    _load: Load
 
     def __init__(
         self,

--- a/custom_components/wiser_by_feller/button.py
+++ b/custom_components/wiser_by_feller/button.py
@@ -19,6 +19,7 @@ from .const import HA_BLUE
 from .coordinator import WiserCoordinator
 from .entity import WiserEntity
 
+PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/wiser_by_feller/climate.py
+++ b/custom_components/wiser_by_feller/climate.py
@@ -1,4 +1,4 @@
-"""Platform for button integration."""
+"""Platform for climate integration."""
 
 from __future__ import annotations
 
@@ -22,6 +22,7 @@ from .const import DOMAIN, MANUFACTURER
 from .coordinator import WiserCoordinator
 from .entity import WiserEntity
 
+PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/wiser_by_feller/climate.py
+++ b/custom_components/wiser_by_feller/climate.py
@@ -33,6 +33,8 @@ def resolve_room(coordinator: WiserCoordinator, group: HvacGroup) -> dict | None
     Unfortunately, the API does not return the sensor's room currently,
     so we can't use that instead.
     """
+    if coordinator.loads is None or coordinator.rooms is None:
+        return None
     rooms = list({coordinator.loads[loadid].room for loadid in group.loads})
     rid = rooms[0] if len(rooms) == 1 else None
 
@@ -47,14 +49,18 @@ async def async_setup_entry(
     """Set up Wiser climate entities."""
     coordinator: WiserCoordinator = entry.runtime_data
 
-    entities = []
+    assert coordinator.devices is not None
+    assert coordinator.states is not None
+    entities: list[ClimateEntity] = []
     for hvac_group in (
         coordinator.hvac_groups.values() if coordinator.hvac_groups is not None else []
     ):
         if hvac_group.thermostat_ref is None:
             continue
 
-        thermostat = coordinator.devices[hvac_group.thermostat_ref.unprefixed_address]
+        thermostat = coordinator.devices.get(
+            hvac_group.thermostat_ref.unprefixed_address
+        )
 
         if thermostat is None:
             continue
@@ -70,6 +76,11 @@ async def async_setup_entry(
 class WiserHvacGroupDeviceEntity:
     """Abstract base class for HVAC group entities."""
 
+    coordinator: WiserCoordinator
+    _hvac_group: HvacGroup | None
+    _room: dict | None
+    _attr_device_unique_id: str
+
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
@@ -78,13 +89,13 @@ class WiserHvacGroupDeviceEntity:
             return None
 
         area = None if self._room is None else self._room["name"]
-        via = (
-            (DOMAIN, self.coordinator.gateway.combined_serial_number)
+        via: tuple[str, str] | None = (
+            (DOMAIN, str(self.coordinator.gateway.combined_serial_number))
             if self.coordinator.gateway is not None
             else None
         )
 
-        return DeviceInfo(
+        info = DeviceInfo(
             identifiers={
                 (
                     DOMAIN,
@@ -95,8 +106,10 @@ class WiserHvacGroupDeviceEntity:
             manufacturer=MANUFACTURER,
             model="HVAC Group",
             suggested_area=area,
-            via_device=via,
         )
+        if via is not None:
+            info["via_device"] = via
+        return info
 
 
 class WiserHvacGroupEntity(WiserHvacGroupDeviceEntity, WiserEntity, ClimateEntity):
@@ -105,6 +118,8 @@ class WiserHvacGroupEntity(WiserHvacGroupDeviceEntity, WiserEntity, ClimateEntit
     These represent a combination of a temperature sensor and one or multiple
     heating valve controllers.
     """
+
+    _hvac_group: HvacGroup
 
     def __init__(
         self,
@@ -133,7 +148,8 @@ class WiserHvacGroupEntity(WiserHvacGroupDeviceEntity, WiserEntity, ClimateEntit
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated entity data from the coordinator."""
-        self._hvac_group.raw_state = self.coordinator.states[self._hvac_group.id]
+        if self.coordinator.states is not None:
+            self._hvac_group.raw_state = self.coordinator.states[self._hvac_group.id]
         self.async_write_ha_state()
 
     @property

--- a/custom_components/wiser_by_feller/config_flow.py
+++ b/custom_components/wiser_by_feller/config_flow.py
@@ -15,6 +15,7 @@ from aiowiserbyfeller import (
     WiserByFellerAPI,
 )
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import AbortFlow
@@ -56,8 +57,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 1
 
-    _reauth_entry: list[str, Any]
-    _reauth_entry_data: list[str, Any]
+    _reauth_entry: ConfigEntry
+    _reauth_entry_data: dict[str, Any]
     _discovered_host: str | None = None
     _discovered_name: str | None = None
 

--- a/custom_components/wiser_by_feller/config_flow.py
+++ b/custom_components/wiser_by_feller/config_flow.py
@@ -205,7 +205,64 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "username": user_input[CONF_USERNAME],
         }
 
-    async def async_step_reauth(self, entry_data: list[str, Any]):
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
+        """Handle reconfiguration of an existing entry (e.g. host IP changed)."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                info = await self.validate_input(self.hass, user_input, True)
+            except (CannotConnect, UnsuccessfulRequest) as e:
+                err = str(e)
+                if "not a directory" in err:
+                    errors["base"] = "invalid_import_user"
+                elif "no site info" in err:
+                    errors["base"] = "no_site_info"
+                else:
+                    errors["base"] = "cannot_connect"
+                _LOGGER.exception("Failed to connect: %s", err)
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+                _LOGGER.exception("Invalid authentication")
+            except ClientResponseError as e:
+                if e.status == 404:
+                    return self.async_abort(reason="not_wiser_gateway")
+                errors["base"] = "cannot_connect"
+                _LOGGER.exception("Unexpected exception")
+            except ConnectionTimeoutError:
+                errors["base"] = "connection_timeout"
+                _LOGGER.exception("Connection timeout")
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                self._abort_if_unique_id_mismatch(reason="wrong_device")
+                return self.async_update_reload_and_abort(reconfigure_entry, data=info)
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOST,
+                        default=reconfigure_entry.data.get(CONF_HOST),
+                    ): cv.string,
+                    vol.Required(
+                        CONF_USERNAME,
+                        default=reconfigure_entry.data.get(
+                            CONF_USERNAME, DEFAULT_API_USER
+                        ),
+                    ): cv.string,
+                    vol.Required(
+                        CONF_IMPORTUSER, default=DEFAULT_IMPORT_USER
+                    ): cv.string,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]):
         """Handle configuration by re-auth."""
         self._reauth_entry_data = entry_data
         self._reauth_entry = self.hass.config_entries.async_get_entry(

--- a/custom_components/wiser_by_feller/config_flow.py
+++ b/custom_components/wiser_by_feller/config_flow.py
@@ -265,9 +265,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reauth(self, entry_data: dict[str, Any]):
         """Handle configuration by re-auth."""
         self._reauth_entry_data = entry_data
-        self._reauth_entry = self.hass.config_entries.async_get_entry(
+        reauth_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
+        assert reauth_entry is not None
+        self._reauth_entry = reauth_entry
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None):

--- a/custom_components/wiser_by_feller/coordinator.py
+++ b/custom_components/wiser_by_feller/coordinator.py
@@ -86,6 +86,7 @@ class WiserCoordinator(DataUpdateCoordinator):
         self._managed_buttons = None
         self._findme_button_future: asyncio.Future | None = None
         self._ws = Websocket(host, token, _LOGGER)
+        self._ws_was_idle = False
 
     @property
     def loads(self) -> dict[int, Load] | None:
@@ -406,12 +407,17 @@ class WiserCoordinator(DataUpdateCoordinator):
 
             # Reconnect WebSocket if it has died
             if self._ws.is_idle():
-                _LOGGER.warning(
-                    "WebSocket connection to µGateway is idle/disconnected. Reconnecting..."
-                )
+                if not self._ws_was_idle:
+                    _LOGGER.warning(
+                        "WebSocket connection to µGateway is idle/disconnected. Reconnecting..."
+                    )
+                    self._ws_was_idle = True
                 await self.ws_close()
                 self._ws.reset_error_count()
                 self._ws.init()
+            elif self._ws_was_idle:
+                _LOGGER.info("WebSocket connection to µGateway re-established.")
+                self._ws_was_idle = False
 
         except asyncio.TimeoutError as err:
             raise UpdateFailed("Timeout while fetching data from µGateway") from err

--- a/custom_components/wiser_by_feller/coordinator.py
+++ b/custom_components/wiser_by_feller/coordinator.py
@@ -512,7 +512,12 @@ class WiserCoordinator(DataUpdateCoordinator):
                 and self.gateway.combined_serial_number != device.combined_serial_number
             ):
                 raise UnexpectedGatewayResult(
-                    f"Multiple WLAN devices returned: {self.gateway.combined_serial_number} and {device.combined_serial_number}"
+                    translation_domain=DOMAIN,
+                    translation_key="multiple_wlan_devices",
+                    translation_placeholders={
+                        "first": self.gateway.combined_serial_number,
+                        "second": device.combined_serial_number,
+                    },
                 )
 
             if info["wlan"]:
@@ -529,7 +534,11 @@ class WiserCoordinator(DataUpdateCoordinator):
         try:
             device.validate_data()
         except aiowiserbyfeller.errors.UnexpectedGatewayResponse as e:
-            raise UnexpectedGatewayResult(f"{e}") from e
+            raise UnexpectedGatewayResult(
+                translation_domain=DOMAIN,
+                translation_key="unexpected_gateway_result",
+                translation_placeholders={"error": str(e)},
+            ) from e
 
     async def async_update_rooms(self) -> None:
         """Update Wiser rooms from µGateway."""

--- a/custom_components/wiser_by_feller/coordinator.py
+++ b/custom_components/wiser_by_feller/coordinator.py
@@ -44,12 +44,12 @@ def get_unique_id(device: Device, load: Load | None) -> str:
     return device.id if load is None else f"{load.device}_{load.channel}"
 
 
-class WiserCoordinator(DataUpdateCoordinator):
+class WiserCoordinator(DataUpdateCoordinator[None]):
     """Class for coordinating all Wiser devices / entities."""
 
     def __init__(
         self,
-        hass,
+        hass: Any,
         api: WiserByFellerAPI,
         host: str,
         token: str,
@@ -65,21 +65,21 @@ class WiserCoordinator(DataUpdateCoordinator):
         self._hass = hass
         self._api = api
         self._options = options
-        self._loads = None
-        self._states = None
-        self._devices = None
-        self._device_ids_by_serial = None
-        self._scenes = None
-        self._sensors = None
-        self._system_flags = None
-        self._system_health = None
-        self._hvac_groups = None
-        self._assigned_thermostats = {}
-        self._jobs = None
-        self._rooms = None
-        self._gateway = None
-        self._gateway_info = None
-        self._managed_buttons = None
+        self._loads: dict[int, Any] | None = None
+        self._states: dict[int, Any] | None = None
+        self._devices: dict[str, Any] | None = None
+        self._device_ids_by_serial: dict[str, str] | None = None
+        self._scenes: dict[int, Any] | None = None
+        self._sensors: dict[int, Any] | None = None
+        self._system_flags: list[Any] | None = None
+        self._system_health: dict[str, Any] | None = None
+        self._hvac_groups: dict[int, Any] | None = None
+        self._assigned_thermostats: dict[str, int] = {}
+        self._jobs: dict[int, Any] | None = None
+        self._rooms: dict[int, Any] | None = None
+        self._gateway: Any = None
+        self._gateway_info: dict[str, Any] | None = None
+        self._managed_buttons: dict[int, Any] | None = None
         self._findme_button_future: asyncio.Future | None = None
         self._ws = Websocket(host, token, _LOGGER)
         self._ws_was_idle = False
@@ -197,6 +197,16 @@ class WiserCoordinator(DataUpdateCoordinator):
         device_id = call.data["device"]
         registry = dr.async_get(self.hass)
         device = registry.async_get(device_id)
+        if (
+            device is None
+            or self._device_ids_by_serial is None
+            or self._devices is None
+        ):
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+                translation_placeholders={"device_id": device_id},
+            )
         sn = device.serial_number
 
         if sn not in self._device_ids_by_serial:

--- a/custom_components/wiser_by_feller/coordinator.py
+++ b/custom_components/wiser_by_feller/coordinator.py
@@ -33,11 +33,7 @@ from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, HA_BLUE, LED_OFF_COLOR, OPTIONS_ALLOW_MISSING_GATEWAY_DATA
-from .exceptions import (
-    InvalidEntityChannelSpecified,
-    InvalidEntitySpecified,
-    UnexpectedGatewayResult,
-)
+from .exceptions import UnexpectedGatewayResult
 from .util import resolve_device_name, rgb_tuple_to_hex
 
 _LOGGER = logging.getLogger(__name__)
@@ -195,9 +191,8 @@ class WiserCoordinator(DataUpdateCoordinator):
         """Wiser by Feller API."""
         return self._api
 
-    async def async_set_status_light(self, call: ServiceCall) -> bool:
+    async def async_set_status_light(self, call: ServiceCall) -> None:
         """Set the button illumination for a channel of a specific device."""
-
         channel = int(call.data["channel"])
         device_id = call.data["device"]
         registry = dr.async_get(self.hass)
@@ -205,13 +200,19 @@ class WiserCoordinator(DataUpdateCoordinator):
         sn = device.serial_number
 
         if sn not in self._device_ids_by_serial:
-            raise InvalidEntitySpecified(f"Device {device_id} not found!")
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+                translation_placeholders={"device_id": device_id},
+            )
 
         wdevice = self._device_ids_by_serial[sn]
 
         if channel >= len(self._devices[wdevice].inputs):
-            raise InvalidEntityChannelSpecified(
-                f"Device {device_id} does not have channel {channel}"
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_channel",
+                translation_placeholders={"channel": str(channel)},
             )
 
         data = {
@@ -224,13 +225,16 @@ class WiserCoordinator(DataUpdateCoordinator):
             ),
         }
 
-        # TODO: Error Handling
-        # TODO: It appears the very first time it does not set the configuration
-        config = await self._api.async_get_device_config(wdevice)
-        await self._api.async_set_device_input_config(config["id"], channel, data)
-        await self._api.async_apply_device_config(config["id"])
-
-        return True
+        try:
+            config = await self._api.async_get_device_config(wdevice)
+            await self._api.async_set_device_input_config(config["id"], channel, data)
+            await self._api.async_apply_device_config(config["id"])
+        except UnsuccessfulRequest as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="status_light_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
     async def async_ping_device(self, device_id: str) -> bool:
         """Device will light up the yellow LEDs of all buttons for a short time."""

--- a/custom_components/wiser_by_feller/cover.py
+++ b/custom_components/wiser_by_feller/cover.py
@@ -40,7 +40,11 @@ async def async_setup_entry(
     """Set up Wiser cover entities."""
     coordinator: WiserCoordinator = entry.runtime_data
 
-    entities = []
+    assert coordinator.loads is not None
+    assert coordinator.states is not None
+    assert coordinator.devices is not None
+    assert coordinator.rooms is not None
+    entities: list[WiserEntity] = []
     for load in coordinator.loads.values():
         load.raw_state = coordinator.states[load.id]
         device = coordinator.devices[load.device]
@@ -60,8 +64,14 @@ async def async_setup_entry(
 class WiserRelayEntity(WiserEntity, CoverEntity):
     """Wiser entity class for basic motor entities."""
 
+    _load: Load
+
     def __init__(
-        self, coordinator: WiserCoordinator, load: Load, device: Device, room: dict
+        self,
+        coordinator: WiserCoordinator,
+        load: Load,
+        device: Device,
+        room: dict | None,
     ) -> None:
         """Set up the relay entity."""
         super().__init__(coordinator, load, device, room)
@@ -72,7 +82,7 @@ class WiserRelayEntity(WiserEntity, CoverEntity):
 
         # There is no suitable default for "motor", so we use shade.
         self._attr_device_class = CoverDeviceClass.SHADE
-        self._tracking_task = None
+        self._tracking_task: asyncio.Task[None] | None = None
 
     @property
     def is_closed(self) -> bool | None:
@@ -165,7 +175,11 @@ class WiserCoverEntity(WiserRelayEntity, CoverEntity):
     """Wiser entity class for non-tiltable covers like shades and awnings."""
 
     def __init__(
-        self, coordinator: WiserCoordinator, load: Load, device: Device, room: dict
+        self,
+        coordinator: WiserCoordinator,
+        load: Load,
+        device: Device,
+        room: dict | None,
     ) -> None:
         """Set up Wiser cover entity."""
         super().__init__(coordinator, load, device, room)
@@ -207,7 +221,11 @@ class WiserTiltableCoverEntity(WiserCoverEntity, CoverEntity):
     """Wiser entity class for tiltable covers like venetian blinds."""
 
     def __init__(
-        self, coordinator: WiserCoordinator, load: Load, device: Device, room: dict
+        self,
+        coordinator: WiserCoordinator,
+        load: Load,
+        device: Device,
+        room: dict | None,
     ) -> None:
         """Set up Wiser tiltable cover entity."""
         super().__init__(coordinator, load, device, room)

--- a/custom_components/wiser_by_feller/cover.py
+++ b/custom_components/wiser_by_feller/cover.py
@@ -28,6 +28,7 @@ from .util import (
     wiser_to_cover_tilt,
 )
 
+PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/wiser_by_feller/diagnostics.py
+++ b/custom_components/wiser_by_feller/diagnostics.py
@@ -20,13 +20,11 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     coordinator: WiserCoordinator = entry.runtime_data
-    assert coordinator.loads is not None
-    assert coordinator.devices is not None
-    assert coordinator.scenes is not None
-    loads_json = [load.raw_data for load in coordinator.loads.values()]
-    devices_json = [
-        coordinator.devices[device_id].raw_data for device_id in coordinator.devices
-    ]
+
+    # Diagnostics should never fail just because some data has not (yet) loaded.
+    # Missing sections are emitted as empty rather than raising.
+    loads_json = [load.raw_data for load in (coordinator.loads or {}).values()]
+    devices_json = [device.raw_data for device in (coordinator.devices or {}).values()]
     gateway_info_json = coordinator.gateway_info
 
     sensors_json = (
@@ -39,10 +37,10 @@ async def async_get_config_entry_diagnostics(
         "entry_data": async_redact_data(entry.data, TO_REDACT),
         "gateway_info": async_redact_data(gateway_info_json, TO_REDACT),
         "loads": async_redact_data(loads_json, TO_REDACT),
-        "rooms": async_redact_data(coordinator.rooms, TO_REDACT),
+        "rooms": async_redact_data(coordinator.rooms or {}, TO_REDACT),
         "devices": async_redact_data(devices_json, TO_REDACT),
         "scenes": async_redact_data(
-            [scene.raw_data for scene in coordinator.scenes.values()], TO_REDACT
+            [scene.raw_data for scene in (coordinator.scenes or {}).values()], TO_REDACT
         ),
         "sensors": async_redact_data(sensors_json, TO_REDACT),
     }
@@ -53,8 +51,6 @@ async def async_get_device_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a device."""
     coordinator: WiserCoordinator = entry.runtime_data
-    assert coordinator.scenes is not None
-    assert coordinator.devices is not None
     result: dict[str, Any] = {}
     result["device"] = async_redact_data(
         json.loads(device.json_repr or b"{}"), TO_REDACT
@@ -63,11 +59,12 @@ async def async_get_device_diagnostics(
     if device.name == f"{entry.title} µGateway":
         result["gateway_info"] = async_redact_data(coordinator.gateway_info, TO_REDACT)
         result["scenes"] = async_redact_data(
-            [scene.raw_data for scene in coordinator.scenes.values()], TO_REDACT
+            [scene.raw_data for scene in (coordinator.scenes or {}).values()], TO_REDACT
         )
     else:
         device_id = next(iter(device.identifiers))[1].partition("_")[0]
-        device_data = coordinator.devices[device_id].raw_data
-        result["device_data"] = async_redact_data(device_data, TO_REDACT)
+        wiser_device = (coordinator.devices or {}).get(device_id)
+        if wiser_device is not None:
+            result["device_data"] = async_redact_data(wiser_device.raw_data, TO_REDACT)
 
     return result

--- a/custom_components/wiser_by_feller/diagnostics.py
+++ b/custom_components/wiser_by_feller/diagnostics.py
@@ -20,6 +20,9 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     coordinator: WiserCoordinator = entry.runtime_data
+    assert coordinator.loads is not None
+    assert coordinator.devices is not None
+    assert coordinator.scenes is not None
     loads_json = [load.raw_data for load in coordinator.loads.values()]
     devices_json = [
         coordinator.devices[device_id].raw_data for device_id in coordinator.devices
@@ -50,8 +53,12 @@ async def async_get_device_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a device."""
     coordinator: WiserCoordinator = entry.runtime_data
+    assert coordinator.scenes is not None
+    assert coordinator.devices is not None
     result: dict[str, Any] = {}
-    result["device"] = async_redact_data(json.loads(device.json_repr), TO_REDACT)
+    result["device"] = async_redact_data(
+        json.loads(device.json_repr or b"{}"), TO_REDACT
+    )
 
     if device.name == f"{entry.title} µGateway":
         result["gateway_info"] = async_redact_data(coordinator.gateway_info, TO_REDACT)

--- a/custom_components/wiser_by_feller/entity.py
+++ b/custom_components/wiser_by_feller/entity.py
@@ -12,7 +12,7 @@ from .coordinator import WiserCoordinator, get_unique_id
 from .util import resolve_device_name
 
 
-class WiserEntity(CoordinatorEntity):
+class WiserEntity(CoordinatorEntity["WiserCoordinator"]):
     """Wiser by Feller base entity."""
 
     def __init__(
@@ -76,13 +76,13 @@ class WiserEntity(CoordinatorEntity):
             else self._device.a["fw_version"]
         )
         area = None if self._room is None else self._room["name"]
-        via = (
-            (DOMAIN, self.coordinator.gateway.combined_serial_number)
+        via: tuple[str, str] | None = (
+            (DOMAIN, str(self.coordinator.gateway.combined_serial_number))
             if self.coordinator.gateway is not None
             else None
         )
 
-        return DeviceInfo(
+        info = DeviceInfo(
             identifiers={
                 (
                     DOMAIN,
@@ -96,11 +96,14 @@ class WiserEntity(CoordinatorEntity):
             sw_version=firmware,
             serial_number=self._device.combined_serial_number,
             suggested_area=area,
-            via_device=via,
         )
+        if via is not None:
+            info["via_device"] = via
+        return info
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated entity data from the coordinator."""
-        self._load.raw_state = self.coordinator.states.get(self._load.id)
+        if self._load is not None and self.coordinator.states is not None:
+            self._load.raw_state = self.coordinator.states.get(self._load.id)
         self.async_write_ha_state()

--- a/custom_components/wiser_by_feller/icons.json
+++ b/custom_components/wiser_by_feller/icons.json
@@ -1,0 +1,29 @@
+{
+  "entity": {
+    "sensor": {
+      "wlan_resets": {
+        "default": "mdi:wifi-alert"
+      },
+      "max_tasks": {
+        "default": "mdi:list-box-outline"
+      },
+      "reboot_cause": {
+        "default": "mdi:restart-alert"
+      },
+      "sockets": {
+        "default": "mdi:arrow-expand-horizontal"
+      },
+      "last_reboot": {
+        "default": "mdi:clock-start"
+      }
+    },
+    "binary_sensor": {
+      "rain": {
+        "default": "mdi:weather-rainy"
+      },
+      "hail": {
+        "default": "mdi:weather-hail"
+      }
+    }
+  }
+}

--- a/custom_components/wiser_by_feller/light.py
+++ b/custom_components/wiser_by_feller/light.py
@@ -34,7 +34,11 @@ async def async_setup_entry(
     """Set up Wiser light entities."""
     coordinator: WiserCoordinator = entry.runtime_data
 
-    entities = []
+    assert coordinator.loads is not None
+    assert coordinator.states is not None
+    assert coordinator.devices is not None
+    assert coordinator.rooms is not None
+    entities: list[WiserEntity] = []
     for load in coordinator.loads.values():
         load.raw_state = coordinator.states[load.id]
         device = coordinator.devices[load.device]
@@ -58,14 +62,20 @@ async def async_setup_entry(
 class WiserOnOffEntity(WiserEntity, LightEntity):
     """Entity class for simple non-dimmable lights."""
 
+    _load: Load
+
     def __init__(
-        self, coordinator: WiserCoordinator, load: Load, device: Device, room: dict
+        self,
+        coordinator: WiserCoordinator,
+        load: Load,
+        device: Device,
+        room: dict | None,
     ) -> None:
         """Set up Wiser on/off light entity."""
         super().__init__(coordinator, load, device, room)
         self._brightness = None
         self._attr_color_mode = ColorMode.ONOFF
-        self._attr_supported_color_modes = [ColorMode.ONOFF]
+        self._attr_supported_color_modes = {ColorMode.ONOFF}
 
     @property
     def is_on(self) -> bool | None:
@@ -90,13 +100,19 @@ class WiserOnOffEntity(WiserEntity, LightEntity):
 class WiserDimEntity(WiserEntity, LightEntity):
     """Entity class for simple dimmable lights."""
 
+    _load: Load
+
     def __init__(
-        self, coordinator: WiserCoordinator, load: Load, device: Device, room: dict
+        self,
+        coordinator: WiserCoordinator,
+        load: Load,
+        device: Device,
+        room: dict | None,
     ) -> None:
         """Set up Wiser dimmable light entity."""
         super().__init__(coordinator, load, device, room)
         self._attr_color_mode = ColorMode.BRIGHTNESS
-        self._attr_supported_color_modes = [ColorMode.BRIGHTNESS]
+        self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
     @property
     def is_on(self) -> bool | None:
@@ -133,6 +149,7 @@ class WiserDimEntity(WiserEntity, LightEntity):
 class WiserDimTwEntity(WiserEntity, LightEntity):
     """Entity class for DALI tunable white dimmable lights."""
 
+    _load: Load
     _attr_color_mode = ColorMode.COLOR_TEMP
     _attr_supported_color_modes = {ColorMode.COLOR_TEMP}
     _attr_min_color_temp_kelvin = 1000
@@ -187,6 +204,7 @@ class WiserDimTwEntity(WiserEntity, LightEntity):
 class WiserDimRgbwEntity(WiserEntity, LightEntity):
     """Entity class for DALI RGBW dimmable lights."""
 
+    _load: Load
     _attr_color_mode = ColorMode.RGBW
     _attr_supported_color_modes = {ColorMode.RGBW}
 

--- a/custom_components/wiser_by_feller/light.py
+++ b/custom_components/wiser_by_feller/light.py
@@ -22,6 +22,7 @@ from .coordinator import WiserCoordinator
 from .entity import WiserEntity
 from .util import brightness_to_wiser, wiser_to_brightness
 
+PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/wiser_by_feller/manifest.json
+++ b/custom_components/wiser_by_feller/manifest.json
@@ -19,8 +19,7 @@
     "aiowiserbyfeller"
   ],
   "requirements": [
-    "aiowiserbyfeller==2.2.0",
-    "websockets>=13.0"
+    "aiowiserbyfeller==2.2.0"
   ],
   "version": "0.2.4",
   "zeroconf": [

--- a/custom_components/wiser_by_feller/manifest.json
+++ b/custom_components/wiser_by_feller/manifest.json
@@ -20,7 +20,7 @@
   ],
   "requirements": [
     "aiowiserbyfeller==2.2.0",
-    "websockets"
+    "websockets>=13.0"
   ],
   "version": "0.2.4",
   "zeroconf": [

--- a/custom_components/wiser_by_feller/scene.py
+++ b/custom_components/wiser_by_feller/scene.py
@@ -25,6 +25,8 @@ async def async_setup_entry(
     """Set up Wiser scenes."""
 
     coordinator: WiserCoordinator = entry.runtime_data
+    assert coordinator.scenes is not None
+    assert coordinator.jobs is not None
     entities = []
 
     for scene in coordinator.scenes.values():
@@ -56,6 +58,7 @@ class WiserSceneEntity(HaScene):
                 "Please fix the root cause and disable the option."
             )
 
+        assert coordinator.config_entry is not None
         gateway = (
             self.coordinator.gateway.combined_serial_number
             if self.coordinator.gateway is not None
@@ -68,5 +71,6 @@ class WiserSceneEntity(HaScene):
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Trigger the Wiser scene."""
+        assert self.coordinator.jobs is not None
         job = self.coordinator.jobs[self._scene.job]
         await job.async_trigger_all()

--- a/custom_components/wiser_by_feller/scene.py
+++ b/custom_components/wiser_by_feller/scene.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import WiserCoordinator
 
+PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/wiser_by_feller/sensor.py
+++ b/custom_components/wiser_by_feller/sensor.py
@@ -96,13 +96,11 @@ GW_SENSORS: tuple[GatewaySensorEntityDescription, ...] = (
     GatewaySensorEntityDescription(
         key="wlan_resets",
         state_class=SensorStateClass.TOTAL,
-        icon="mdi:wifi-alert",
         value_fn=lambda data: data.get("wlan_resets"),
     ),
     GatewaySensorEntityDescription(
         key="max_tasks",
         state_class=SensorStateClass.TOTAL,
-        icon="mdi:list-box-outline",
         value_fn=lambda data: data.get("max_tasks"),
     ),
     GatewaySensorEntityDescription(
@@ -114,13 +112,11 @@ GW_SENSORS: tuple[GatewaySensorEntityDescription, ...] = (
     ),
     GatewaySensorEntityDescription(
         key="reboot_cause",
-        icon="mdi:restart-alert",
         value_fn=lambda data: data.get("reboot_cause"),
     ),
     GatewaySensorEntityDescription(
         key="sockets",
         state_class=SensorStateClass.TOTAL,
-        icon="mdi:arrow-expand-horizontal",
         value_fn=lambda data: data.get("sockets"),
     ),
 )
@@ -244,7 +240,6 @@ class WiserLastRebootEntity(CoordinatorEntity, SensorEntity):
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
         self._attr_has_entity_name = True
-        self._attr_icon = "mdi:clock-start"
 
     @property
     def native_value(self) -> datetime:
@@ -377,7 +372,6 @@ class WiserRainSensorEntity(WiserSensorEntity, BinarySensorEntity):
         super().__init__(coordinator, device, room, sensor)
         self._attr_unique_id = f"{self._attr_raw_unique_id}_rain"
         self._attr_translation_key = "rain"
-        self._attr_icon = "mdi:weather-rainy"
 
     @property
     def is_on(self) -> bool | None:
@@ -393,7 +387,6 @@ class WiserHailSensorEntity(WiserSensorEntity, BinarySensorEntity):
         super().__init__(coordinator, device, room, sensor)
         self._attr_unique_id = f"{self._attr_raw_unique_id}_hail"
         self._attr_translation_key = "hail"
-        self._attr_icon = "mdi:weather-hail"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/wiser_by_feller/sensor.py
+++ b/custom_components/wiser_by_feller/sensor.py
@@ -37,6 +37,7 @@ from .const import DOMAIN
 from .coordinator import WiserCoordinator
 from .entity import WiserEntity
 
+PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 RESTART_DELTA_THRESHOLD = 120
 

--- a/custom_components/wiser_by_feller/sensor.py
+++ b/custom_components/wiser_by_feller/sensor.py
@@ -131,10 +131,13 @@ async def async_setup_entry(
 
     coordinator: WiserCoordinator = entry.runtime_data
 
-    entities = [
+    assert coordinator.devices is not None
+    assert coordinator.states is not None
+    assert coordinator.rooms is not None
+    entities: list[SensorEntity | BinarySensorEntity] = [
         WiserSystemHealthEntity(coordinator, description)
         for description in GW_SENSORS
-        if coordinator.gateway_api_major_version >= description.min_api_version
+        if (coordinator.gateway_api_major_version or 0) >= description.min_api_version
     ]
 
     entities.append(WiserLastRebootEntity(coordinator))
@@ -189,7 +192,7 @@ async def async_setup_entry(
 
 
 # TODO: Is this compatible with iot_class local_push?
-class WiserSystemHealthEntity(CoordinatorEntity, SensorEntity):
+class WiserSystemHealthEntity(CoordinatorEntity["WiserCoordinator"], SensorEntity):
     """A Wiser µGateway system health sensor entity."""
 
     entity_description: GatewaySensorEntityDescription
@@ -203,6 +206,7 @@ class WiserSystemHealthEntity(CoordinatorEntity, SensorEntity):
     ) -> None:
         """Set up the entity."""
         super().__init__(coordinator, entity_description)
+        assert coordinator.gateway is not None
         self.gateway = coordinator.gateway.combined_serial_number
         slugify_gateway = slugify(f"{self.gateway}", separator="_")
         self.entity_description = entity_description
@@ -212,7 +216,7 @@ class WiserSystemHealthEntity(CoordinatorEntity, SensorEntity):
         self.coordinator_context = f"{slugify_gateway}_{entity_description.key}"
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self.gateway)})
         self._attr_native_value = self.entity_description.value_fn(
-            self.coordinator.system_health
+            self.coordinator.system_health or {}
         )
 
     @callback
@@ -220,16 +224,17 @@ class WiserSystemHealthEntity(CoordinatorEntity, SensorEntity):
         """Handle updated data from the coordinator."""
         super()._handle_coordinator_update()
         self._attr_native_value = self.entity_description.value_fn(
-            self.coordinator.system_health
+            self.coordinator.system_health or {}
         )
 
 
-class WiserLastRebootEntity(CoordinatorEntity, SensorEntity):
+class WiserLastRebootEntity(CoordinatorEntity["WiserCoordinator"], SensorEntity):
     """A Wiser µGateway system health sensor entity to return the last reboot."""
 
     def __init__(self, coordinator: WiserCoordinator) -> None:
         """Set up the entity."""
         super().__init__(coordinator)
+        assert coordinator.gateway is not None
         self.gateway = coordinator.gateway.combined_serial_number
         slugify_gateway = slugify(f"{self.gateway}", separator="_")
         self._attr_translation_key = "last_reboot"
@@ -249,6 +254,7 @@ class WiserLastRebootEntity(CoordinatorEntity, SensorEntity):
         which is not ideal. Therefore, we calculate the timestamp of the last reboot. We return the new value only,
         if it differs more than the configured threshold.
         """
+        assert self.coordinator.system_health is not None
         new_value = dt_util.utcnow() - dt_util.dt.timedelta(
             seconds=self.coordinator.system_health["uptime"]
         )
@@ -292,9 +298,10 @@ class WiserSensorEntity(WiserEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        state = self.coordinator.states.get(self._sensor.id)
-        if state is not None:
-            self._sensor.raw_data = state
+        if self.coordinator.states is not None:
+            state = self.coordinator.states.get(self._sensor.id)
+            if state is not None:
+                self._sensor.raw_data = state
         self.async_write_ha_state()
 
 

--- a/custom_components/wiser_by_feller/services.yaml
+++ b/custom_components/wiser_by_feller/services.yaml
@@ -40,6 +40,14 @@ set_button_led_override:
   name: Set Button LED Override
   description: Set a temporary LED override on a Wiser button LED.
   fields:
+    config_entry_id:
+      name: µGateway
+      description: The µGateway the button belongs to. Optional if you only have one; required when multiple µGateways are configured.
+      required: false
+      selector:
+        config_entry:
+          integration: wiser_by_feller
+
     button_id:
       name: Button ID
       description: Wiser button ID. Use the `find_button` service to discover it.
@@ -89,6 +97,14 @@ clear_button_led_override:
   name: Clear Button LED Override
   description: Disable the temporary LED override and return to the configured Wiser LED behavior.
   fields:
+    config_entry_id:
+      name: µGateway
+      description: The µGateway the button belongs to. Optional if you only have one; required when multiple µGateways are configured.
+      required: false
+      selector:
+        config_entry:
+          integration: wiser_by_feller
+
     button_id:
       name: Button ID
       description: Wiser button ID. Use the Find Button service to discover it.
@@ -114,3 +130,11 @@ find_button:
     Activates find-me mode on all buttons. All button LEDs start blinking.
     Press any physical button to identify it. The button ID, device, channel,
     label, and LED options are returned as the service response and shown as a notification.
+  fields:
+    config_entry_id:
+      name: µGateway
+      description: The µGateway to activate find-me mode on. Optional if you only have one; required when multiple µGateways are configured.
+      required: false
+      selector:
+        config_entry:
+          integration: wiser_by_feller

--- a/custom_components/wiser_by_feller/switch.py
+++ b/custom_components/wiser_by_feller/switch.py
@@ -32,6 +32,11 @@ async def async_setup_entry(
 
     coordinator: WiserCoordinator = entry.runtime_data
 
+    assert coordinator.loads is not None
+    assert coordinator.states is not None
+    assert coordinator.devices is not None
+    assert coordinator.rooms is not None
+
     entities: list = [
         WiserSystemFlag(coordinator, flag) for flag in coordinator.system_flags or []
     ]
@@ -53,8 +58,14 @@ async def async_setup_entry(
 class WiserOnOffSwitchEntity(WiserEntity, SwitchEntity):
     """Entity class for simple on/off switches configured as such in the Wiser ecosystem (outlets, fans, etc.)."""
 
+    _load: Load
+
     def __init__(
-        self, coordinator: WiserCoordinator, load: Load, device: Device, room: dict
+        self,
+        coordinator: WiserCoordinator,
+        load: Load,
+        device: Device,
+        room: dict | None,
     ) -> None:
         """Set up Wiser on/off switch entity."""
         super().__init__(coordinator, load, device, room)
@@ -79,7 +90,7 @@ class WiserOnOffSwitchEntity(WiserEntity, SwitchEntity):
         self._load.raw_state["bri"] = 0
 
 
-class WiserSystemFlag(CoordinatorEntity, SwitchEntity):
+class WiserSystemFlag(CoordinatorEntity["WiserCoordinator"], SwitchEntity):
     """Entity class for system flags in the Wiser ecosystem."""
 
     _attr_has_entity_name = True
@@ -100,6 +111,7 @@ class WiserSystemFlag(CoordinatorEntity, SwitchEntity):
                 "Please fix the root cause and disable the option."
             )
 
+        assert coordinator.config_entry is not None
         gateway = (
             coordinator.gateway.combined_serial_number
             if coordinator.gateway is not None

--- a/custom_components/wiser_by_feller/switch.py
+++ b/custom_components/wiser_by_feller/switch.py
@@ -18,6 +18,7 @@ from .const import DOMAIN
 from .coordinator import WiserCoordinator
 from .entity import WiserEntity
 
+PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/wiser_by_feller/switch.py
+++ b/custom_components/wiser_by_feller/switch.py
@@ -9,6 +9,7 @@ from aiowiserbyfeller import Device, Load, OnOff, SystemFlag
 from aiowiserbyfeller.const import KIND_SWITCH
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -82,6 +83,7 @@ class WiserSystemFlag(CoordinatorEntity, SwitchEntity):
     """Entity class for system flags in the Wiser ecosystem."""
 
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self,

--- a/custom_components/wiser_by_feller/translations/en.json
+++ b/custom_components/wiser_by_feller/translations/en.json
@@ -153,6 +153,17 @@
       "description": "Sensor \"{item_name}\" (ID: {item_id}) has an unknown type \"{item_type}\" and is not supported by this integration. It will be ignored until support is added.\n\nIf you are using pre-production devices, please report this sensor type to the integration maintainers so it can be added."
     }
   },
+  "exceptions": {
+    "device_not_found": {
+      "message": "Device {device_id} was not found."
+    },
+    "invalid_channel": {
+      "message": "Channel {channel} does not exist on this device."
+    },
+    "status_light_failed": {
+      "message": "Failed to set status light: {error}"
+    }
+  },
   "services": {
     "status_light": {
       "name": "Configure status light",

--- a/custom_components/wiser_by_feller/translations/en.json
+++ b/custom_components/wiser_by_feller/translations/en.json
@@ -189,6 +189,9 @@
     },
     "specify_gateway": {
       "message": "Multiple µGateways are configured. Select which one in the µGateway field."
+    },
+    "unmanaged_button": {
+      "message": "This button is unmanaged. See the LED Control documentation for more information: https://github.com/Syonix/ha-wiser-by-feller/blob/main/docs/led-control.md"
     }
   },
   "services": {
@@ -265,7 +268,6 @@
     "find_button": {
       "name": "Find Button",
       "description": "Activates find-me mode: all button LEDs start blinking. Press any physical button to identify it. The button ID, device, channel, and structured label fields are returned and shown as a notification.",
-      "note_unmanaged_button": "This button is unmanaged. See docs for more information.",
       "fields": {
         "config_entry_id": {
           "name": "µGateway",

--- a/custom_components/wiser_by_feller/translations/en.json
+++ b/custom_components/wiser_by_feller/translations/en.json
@@ -16,6 +16,20 @@
           "import_user": "The user to import existing Wiser configuration from (like scenes, rooms and load names). If you don't have any other systems using the API, you can choose between 'installer' (Wiser eSetup app) and 'admin' (Wiser Home app)."
         }
       },
+      "reconfigure": {
+        "title": "Reconfigure Wiser by Feller \u00b5Gateway",
+        "description": "Update the connection details for your \u00b5Gateway. Press any flashing button on the device within 30 seconds to reconnect.",
+        "data": {
+          "host": "Host",
+          "username": "Username",
+          "import_user": "Import config from"
+        },
+        "data_description": {
+          "host": "The new hostname or IP address of your \u00b5Gateway.",
+          "username": "The username to be used for the API.",
+          "import_user": "The user to import existing Wiser configuration from."
+        }
+      },
       "reauth_confirm": {
         "title": "Reconnect Wiser by Feller \u00b5Gateway",
         "description": "Enter the IP address of your \u00b5Gateway and click submit. The buttons should start to flash pink and purple. Press any of the flashing buttons on the \u00b5Gateway within 30 seconds to connect your Home Assistant instance.",
@@ -36,7 +50,8 @@
       "already_configured": "Device is already configured",
       "already_in_progress": "Configuration flow is already in progress",
       "no_gateways": "No Wiser \u00b5Gateways discovered",
-      "not_wiser_gateway": "The device you're trying to connect to is not a Wiser \u00b5Gateway. Are you sure you've entered the correct hostname or IP?"
+      "not_wiser_gateway": "The device you're trying to connect to is not a Wiser \u00b5Gateway. Are you sure you've entered the correct hostname or IP?",
+      "wrong_device": "The device at the new address has a different serial number. Use this flow only to update the address of the same \u00b5Gateway."
     },
     "error": {
       "cannot_connect": "Failed to connect",

--- a/custom_components/wiser_by_feller/translations/en.json
+++ b/custom_components/wiser_by_feller/translations/en.json
@@ -183,6 +183,12 @@
     },
     "multiple_wlan_devices": {
       "message": "Multiple WLAN devices found in the same network: {first} and {second}. Only one µGateway per network is supported."
+    },
+    "no_gateway_loaded": {
+      "message": "No Wiser µGateway is currently loaded."
+    },
+    "specify_gateway": {
+      "message": "Multiple µGateways are configured. Select which one in the µGateway field."
     }
   },
   "services": {
@@ -216,6 +222,10 @@
       "name": "Set Button LED Override",
       "description": "Set a temporary LED override on a Wiser button LED.",
       "fields": {
+        "config_entry_id": {
+          "name": "µGateway",
+          "description": "The µGateway the button belongs to. Optional with a single gateway; required when multiple are configured."
+        },
         "button_id": {
           "name": "Button ID",
           "description": "Wiser button ID. Use the Find Button service to discover it."
@@ -238,6 +248,10 @@
       "name": "Clear Button LED Override",
       "description": "Disable the temporary LED override and return to the configured Wiser LED behavior.",
       "fields": {
+        "config_entry_id": {
+          "name": "µGateway",
+          "description": "The µGateway the button belongs to. Optional with a single gateway; required when multiple are configured."
+        },
         "button_id": {
           "name": "Button ID",
           "description": "Wiser button ID. Use the Find Button service to discover it."
@@ -251,7 +265,13 @@
     "find_button": {
       "name": "Find Button",
       "description": "Activates find-me mode: all button LEDs start blinking. Press any physical button to identify it. The button ID, device, channel, and structured label fields are returned and shown as a notification.",
-      "note_unmanaged_button": "This button is unmanaged. See docs for more information."
+      "note_unmanaged_button": "This button is unmanaged. See docs for more information.",
+      "fields": {
+        "config_entry_id": {
+          "name": "µGateway",
+          "description": "The µGateway to activate find-me mode on. Optional with a single gateway; required when multiple are configured."
+        }
+      }
     }
   }
 }

--- a/custom_components/wiser_by_feller/translations/en.json
+++ b/custom_components/wiser_by_feller/translations/en.json
@@ -162,6 +162,12 @@
     },
     "status_light_failed": {
       "message": "Failed to set status light: {error}"
+    },
+    "unexpected_gateway_result": {
+      "message": "Unexpected response from the µGateway: {error}"
+    },
+    "multiple_wlan_devices": {
+      "message": "Multiple WLAN devices found in the same network: {first} and {second}. Only one µGateway per network is supported."
     }
   },
   "services": {

--- a/docs/led-control.md
+++ b/docs/led-control.md
@@ -2,14 +2,14 @@
 
 Wiser by Feller devices have customizable status LEDs that can indicate load states or system status. There are two ways to control these LEDs, which are fundamentally different in how they work and what they are meant to be used for:
 
-| | ⚙️ Device Configuration | 🕐 Temporary Override |
-|---|---|---|
-| **What it changes** | The LED configuration stored on the device | A temporary override on top of the configuration |
-| **Targeted by** | Wiser device and button position | Button ID |
-| **Reacts to load state** | ✅ Yes | ❌ No |
-| **Persists** | Until reconfigured (can be overridden) | Until reboot or cleared |
-| **Performance** | 🐌 Slow | 🚀 Fast |
-| **Purpose** | To represent load state (e.g. show if the light is on) or use as orientation light in the dark | Use in HA automations (e.g. notifications, show air quality, etc.)
+|                          | ⚙️ Device Configuration                                                                        | 🕐 Temporary Override                                              |
+|--------------------------|------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
+| **What it changes**      | The LED configuration stored on the device                                                     | A temporary override on top of the configuration                   |
+| **Targeted by**          | Wiser device and button position                                                               | Button ID                                                          |
+| **Reacts to load state** | ✅ Yes                                                                                          | ❌ No                                                               |
+| **Persists**             | Until reconfigured (can be overridden)                                                         | Until reboot or cleared                                            |
+| **Performance**          | 🐌 Slow                                                                                        | 🚀 Fast                                                            |
+| **Purpose**              | To represent load state (e.g. show if the light is on) or use as orientation light in the dark | Use in HA automations (e.g. notifications, show air quality, etc.) |
 
 ## ⚙️ Device Configuration
 The first method modifies the LED configuration directly on the device. This is the same configuration available in the Wiser apps (Frontset-Eigenschaften). You set a color and brightness levels for when the load is on and when it is off, and the device automatically switches the LEDs based on the actual load state.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,3 +180,6 @@ max-complexity = 25
 
 [tool.ruff.lint.pydocstyle]
 property-decorators = ["propcache.api.cached_property"]
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -515,6 +515,136 @@ async def test_reauth_invalid_auth(hass: HomeAssistant, mock_setup_entry) -> Non
 
 
 # ---------------------------------------------------------------------------
+# Reconfigure flow
+# ---------------------------------------------------------------------------
+
+
+async def test_reconfigure_success(
+    hass: HomeAssistant, mock_wiser_api, mock_setup_entry
+) -> None:
+    """A valid reconfigure submission updates the host and reloads the entry."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": MOCK_HOST,
+            "token": "old-token",
+            "sn": MOCK_SN,
+            "username": MOCK_USERNAME,
+            "title": MOCK_SITE_NAME,
+        },
+        unique_id=MOCK_SN,
+    )
+    entry.add_to_hass(hass)
+
+    new_host = "192.168.1.200"
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_HOST: new_host,
+            CONF_USERNAME: MOCK_USERNAME,
+            CONF_IMPORTUSER: MOCK_IMPORT_USER,
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data["host"] == new_host
+    assert entry.data["token"] == MOCK_TOKEN
+
+
+async def test_reconfigure_wrong_device(hass: HomeAssistant, mock_setup_entry) -> None:
+    """Reconfigure aborts when the new address points to a different gateway."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": MOCK_HOST, "token": "old-token", "sn": MOCK_SN},
+        unique_id=MOCK_SN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    different_sn = "DIFFERENT000"
+    mock_api = AsyncMock()
+    mock_api.async_get_info.return_value = {
+        "sn": different_sn,
+        "hostname": "other-wiser",
+    }
+    mock_api.async_get_site_info.return_value = MOCK_SITE
+    mock_auth = AsyncMock()
+    mock_auth.claim.return_value = MOCK_TOKEN
+
+    with (
+        patch(
+            "custom_components.wiser_by_feller.config_flow.WiserByFellerAPI",
+            return_value=mock_api,
+        ),
+        patch(
+            "custom_components.wiser_by_feller.config_flow.Auth",
+            return_value=mock_auth,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"
+
+
+async def test_reconfigure_cannot_connect(
+    hass: HomeAssistant, mock_setup_entry
+) -> None:
+    """A connection failure during reconfigure shows the cannot_connect error."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": MOCK_HOST, "token": "old-token", "sn": MOCK_SN},
+        unique_id=MOCK_SN,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+
+    with patch(
+        "custom_components.wiser_by_feller.config_flow.WiserByFellerAPI",
+        side_effect=CannotConnect,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+# ---------------------------------------------------------------------------
 # Options flow
 # ---------------------------------------------------------------------------
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -523,8 +523,6 @@ async def test_reconfigure_success(
     hass: HomeAssistant, mock_wiser_api, mock_setup_entry
 ) -> None:
     """A valid reconfigure submission updates the host and reloads the entry."""
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -566,8 +564,6 @@ async def test_reconfigure_success(
 
 async def test_reconfigure_wrong_device(hass: HomeAssistant, mock_setup_entry) -> None:
     """Reconfigure aborts when the new address points to a different gateway."""
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"host": MOCK_HOST, "token": "old-token", "sn": MOCK_SN},
@@ -615,8 +611,6 @@ async def test_reconfigure_cannot_connect(
     hass: HomeAssistant, mock_setup_entry
 ) -> None:
     """A connection failure during reconfigure shows the cannot_connect error."""
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"host": MOCK_HOST, "token": "old-token", "sn": MOCK_SN},

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,6 +1,7 @@
 """Tests for WiserCoordinator."""
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiowiserbyfeller import (
@@ -470,8 +471,6 @@ async def test_ws_idle_logs_warning_once(coordinator, mock_api, caplog):
     """WebSocket idle triggers a warning only on the first detection, not every poll."""
     coordinator._ws.is_idle.return_value = True
 
-    import logging
-
     with caplog.at_level(logging.WARNING):
         await coordinator._async_update_data()
         await coordinator._async_update_data()
@@ -485,8 +484,6 @@ async def test_ws_idle_recovery_logs_info(coordinator, mock_api, caplog):
     """After being idle, a successful reconnect logs an info recovery message."""
     coordinator._ws_was_idle = True
     coordinator._ws.is_idle.return_value = False
-
-    import logging
 
     with caplog.at_level(logging.INFO):
         await coordinator._async_update_data()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -464,3 +464,32 @@ def test_resolve_button_fields_scene_none_when_button_has_no_job(coordinator):
     coordinator._rooms = {}
     coordinator._scenes = {1: _make_scene_for_coord(job_id=100)}
     assert coordinator.resolve_managed_button_fields(1)["scene_name"] is None
+
+
+async def test_ws_idle_logs_warning_once(coordinator, mock_api, caplog):
+    """WebSocket idle triggers a warning only on the first detection, not every poll."""
+    coordinator._ws.is_idle.return_value = True
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        await coordinator._async_update_data()
+        await coordinator._async_update_data()
+
+    warnings = [r for r in caplog.records if "idle" in r.message.lower()]
+    assert len(warnings) == 1
+    assert coordinator._ws_was_idle is True
+
+
+async def test_ws_idle_recovery_logs_info(coordinator, mock_api, caplog):
+    """After being idle, a successful reconnect logs an info recovery message."""
+    coordinator._ws_was_idle = True
+    coordinator._ws.is_idle.return_value = False
+
+    import logging
+
+    with caplog.at_level(logging.INFO):
+        await coordinator._async_update_data()
+
+    assert coordinator._ws_was_idle is False
+    assert any("re-established" in r.message.lower() for r in caplog.records)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,6 @@
 """Tests for integration setup/teardown (__init__.py)."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiowiserbyfeller import UnsuccessfulRequest
 from homeassistant.config_entries import ConfigEntryState
@@ -8,7 +8,10 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 import pytest
 
-from custom_components.wiser_by_feller import async_setup_gateway
+from custom_components.wiser_by_feller import (
+    async_remove_stale_devices,
+    async_setup_gateway,
+)
 from custom_components.wiser_by_feller.const import DOMAIN
 
 # ── setup ────────────────────────────────────────────────────────────────────
@@ -86,6 +89,69 @@ async def test_setup_gateway_missing_uses_fallback(
     device = registry.async_get_device({(DOMAIN, mock_config_entry.title)})
     assert device is not None
     assert device.name == "Unknown µGateway"
+
+
+# ── stale device cleanup ──────────────────────────────────────────────────────
+
+
+async def test_remove_stale_devices_removes_orphan(
+    hass, mock_config_entry, mock_coordinator
+):
+    """Devices in the registry whose identifier is no longer in the coordinator are removed."""
+    mock_config_entry.add_to_hass(hass)
+    registry = dr.async_get(hass)
+
+    stale = registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "stale_device_001")},
+    )
+
+    mock_coordinator.loads = {}
+    mock_coordinator.devices = {}
+    mock_coordinator.hvac_groups = {}
+
+    await async_remove_stale_devices(hass, mock_config_entry, mock_coordinator)
+
+    assert registry.async_get(stale.id) is None
+
+
+async def test_remove_stale_devices_keeps_gateway(
+    hass, mock_config_entry, mock_coordinator
+):
+    """The gateway device entry is preserved when the gateway is still present."""
+    mock_config_entry.add_to_hass(hass)
+    registry = dr.async_get(hass)
+
+    gateway_device = registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, mock_coordinator.gateway.combined_serial_number)},
+    )
+
+    await async_remove_stale_devices(hass, mock_config_entry, mock_coordinator)
+
+    assert registry.async_get(gateway_device.id) is not None
+
+
+async def test_remove_stale_devices_keeps_known_load(
+    hass, mock_config_entry, mock_coordinator
+):
+    """A device whose identifier matches an active load is not removed."""
+    mock_config_entry.add_to_hass(hass)
+    registry = dr.async_get(hass)
+
+    load = MagicMock()
+    load.device = "00000679"
+    load.channel = 0
+    mock_coordinator.loads = {1: load}
+
+    known = registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "00000679_0")},
+    )
+
+    await async_remove_stale_devices(hass, mock_config_entry, mock_coordinator)
+
+    assert registry.async_get(known.id) is not None
 
 
 # ── unload ────────────────────────────────────────────────────────────────────

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -42,7 +42,7 @@ async def test_setup_entry_forwards_all_platforms(
 
 
 async def test_setup_entry_registers_status_light_service(hass, setup_integration):
-    """async_setup_entry registers the 'status_light' service under the domain."""
+    """async_setup registers the 'status_light' service under the domain."""
     assert hass.services.has_service(DOMAIN, "status_light")
 
 
@@ -99,12 +99,17 @@ async def test_unload_entry_calls_ws_close(hass, setup_integration, mock_coordin
     mock_coordinator.ws_close.assert_called_once()
 
 
-async def test_unload_entry_removes_service(hass, setup_integration):
-    """async_unload_entry removes the 'status_light' service from hass.services."""
+async def test_unload_entry_keeps_service(hass, setup_integration):
+    """async_unload_entry does not remove the 'status_light' service.
+
+    The service is registered once in async_setup (not per config entry) so it
+    persists as long as the integration is loaded, regardless of how many entries
+    are active.
+    """
     entry = setup_integration
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert not hass.services.has_service(DOMAIN, "status_light")
+    assert hass.services.has_service(DOMAIN, "status_light")
 
 
 # ── find_button service ───────────────────────────────────────────────────────

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -215,13 +215,13 @@ async def test_find_button_managed_button_returns_fields(
     assert response["room_name"] == "Living Room"
     assert response["device_name"] == "Dimmer Plus"
     assert response["scene_name"] is None
-    assert response["note"] is None
+    assert "note" not in response
 
 
-async def test_find_button_managed_button_no_note(
+async def test_find_button_managed_button_returns_no_note(
     hass, setup_integration, mock_coordinator
 ):
-    """Managed button: note is None regardless of translations."""
+    """Managed button responses never carry a note field."""
     mock_coordinator.async_find_button = AsyncMock(
         return_value={"button_id": 5, "device": "aabbccdd", "channel": 0}
     )
@@ -230,51 +230,22 @@ async def test_find_button_managed_button_no_note(
         DOMAIN, "find_button", {}, blocking=True, return_response=True
     )
 
-    assert response["note"] is None
+    assert "note" not in response
 
 
-async def test_find_button_unmanaged_button_sets_note(
+async def test_find_button_unmanaged_button_raises(
     hass, setup_integration, mock_coordinator
 ):
-    """Unmanaged button: response contains device/channel and a translated note."""
+    """Unmanaged button raises a validation error pointing to the docs."""
     mock_coordinator.async_find_button = AsyncMock(
         return_value={"button_id": None, "device": "00019edc", "channel": 0}
     )
-    with patch(
-        "custom_components.wiser_by_feller.async_get_translations",
-        return_value={
-            f"component.{DOMAIN}.services.find_button.note_unmanaged_button": "Unmanaged note."
-        },
-    ):
-        response = await hass.services.async_call(
+    with pytest.raises(ServiceValidationError) as exc:
+        await hass.services.async_call(
             DOMAIN, "find_button", {}, blocking=True, return_response=True
         )
 
-    assert response["button_id"] is None
-    assert response["device"] == "00019edc"
-    assert response["channel"] == 0
-    assert response["note"] == "Unmanaged note."
-    assert response["room_name"] is None
-    assert response["device_name"] is None
-    assert response["scene_name"] is None
-
-
-async def test_find_button_unmanaged_falls_back_when_translation_missing(
-    hass, setup_integration, mock_coordinator
-):
-    """Unmanaged button: falls back to the hardcoded English note when translation key absent."""
-    mock_coordinator.async_find_button = AsyncMock(
-        return_value={"button_id": None, "device": "00019edc", "channel": 0}
-    )
-    with patch(
-        "custom_components.wiser_by_feller.async_get_translations",
-        return_value={},
-    ):
-        response = await hass.services.async_call(
-            DOMAIN, "find_button", {}, blocking=True, return_response=True
-        )
-
-    assert "unmanaged" in response["note"].lower()
+    assert exc.value.translation_key == "unmanaged_button"
 
 
 async def test_find_button_creates_notification(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,6 +7,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.wiser_by_feller import (
     async_remove_stale_devices,
@@ -165,17 +166,20 @@ async def test_unload_entry_calls_ws_close(hass, setup_integration, mock_coordin
     mock_coordinator.ws_close.assert_called_once()
 
 
-async def test_unload_entry_keeps_service(hass, setup_integration):
-    """async_unload_entry does not remove the 'status_light' service.
+async def test_unload_entry_keeps_services(hass, setup_integration):
+    """async_unload_entry does not remove any service.
 
-    The service is registered once in async_setup (not per config entry) so it
-    persists as long as the integration is loaded, regardless of how many entries
-    are active.
+    All services are registered once in async_setup (not per config entry) so
+    they persist as long as the integration is loaded, regardless of how many
+    entries are active.
     """
     entry = setup_integration
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
     assert hass.services.has_service(DOMAIN, "status_light")
+    assert hass.services.has_service(DOMAIN, "set_button_led_override")
+    assert hass.services.has_service(DOMAIN, "clear_button_led_override")
+    assert hass.services.has_service(DOMAIN, "find_button")
 
 
 # ── find_button service ───────────────────────────────────────────────────────
@@ -324,5 +328,78 @@ async def test_clear_button_led_override_raises_service_error_on_api_failure(
             DOMAIN,
             "clear_button_led_override",
             {"button_id": 43, "led_index": "0"},
+            blocking=True,
+        )
+
+
+# ── gateway selection for button services ─────────────────────────────────────
+
+
+async def test_button_service_uses_explicit_gateway(
+    hass, setup_integration, mock_coordinator
+):
+    """An explicit config_entry_id routes the call to that gateway's coordinator."""
+    entry = setup_integration
+    mock_coordinator.api.async_set_button_led = AsyncMock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_button_led_override",
+        {
+            "config_entry_id": entry.entry_id,
+            "button_id": 7,
+            "led_index": "0",
+            "rgb_color": [1, 2, 3],
+        },
+        blocking=True,
+    )
+
+    mock_coordinator.api.async_set_button_led.assert_awaited_once()
+
+
+async def test_button_service_unknown_gateway_raises(hass, setup_integration):
+    """An unknown config_entry_id raises a validation error."""
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_button_led_override",
+            {
+                "config_entry_id": "does-not-exist",
+                "button_id": 7,
+                "led_index": "0",
+                "rgb_color": [1, 2, 3],
+            },
+            blocking=True,
+        )
+
+
+async def test_button_service_requires_gateway_when_multiple(
+    hass, setup_integration, mock_coordinator
+):
+    """With several µGateways loaded and no selection, the service errors clearly."""
+    # A first gateway is already loaded via setup_integration; add a second.
+    second = MockConfigEntry(
+        domain=DOMAIN,
+        title="Second Wiser",
+        data={"host": "192.168.1.101", "token": "t"},
+        unique_id="SECOND_SN",
+    )
+    second.add_to_hass(hass)
+    with (
+        patch("custom_components.wiser_by_feller.Auth"),
+        patch("custom_components.wiser_by_feller.WiserByFellerAPI"),
+        patch(
+            "custom_components.wiser_by_feller.WiserCoordinator",
+            return_value=mock_coordinator,
+        ),
+    ):
+        await hass.config_entries.async_setup(second.entry_id)
+        await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError, match="Multiple"):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_button_led_override",
+            {"button_id": 1, "led_index": "0", "rgb_color": [255, 0, 0]},
             blocking=True,
         )


### PR DESCRIPTION
This PR implements several rules from the [HA Integration Quality Scale](https://developers.home-assistant.io/docs/core/integration-quality-scale/) to move the integration from Silver toward Gold and Platinum tier.

> Note: this is a custom component, so the quality scale rules are applied as guidelines rather than CI-gated requirements. Core-only mechanisms (e.g. the `.strict-typing` file) do not apply here.

## Implemented in this PR

**Bronze tier:**
- `action-setup` — `status_light` is now registered in `async_setup` instead of `async_setup_entry`, so it exists even when no config entry is loaded. The handler resolves the target device's config entry at call time (supporting multiple µGateways) and raises `ServiceValidationError` when the device or entry cannot be found.
- `parallel-updates` — added an explicit `PARALLEL_UPDATES = 0` to every platform, since the coordinator centralizes data updates.

**Silver tier:**
- `action-exceptions` — the `status_light` action now raises `ServiceValidationError` for invalid input (unknown device / channel) instead of custom integration exceptions.
- `log-when-unavailable` — the WebSocket idle/reconnect message is now logged once per state transition (via a `_ws_was_idle` flag) instead of on every poll cycle, plus an info-level message when the connection is re-established.

**Gold tier:**
- `icon-translations` — moved hardcoded `mdi:*` icons out of the entity descriptions and into `icons.json`.
- `exception-translations` — added `translation_domain`/`translation_key` to the custom exceptions (e.g. `UnexpectedGatewayResult`) and defined the messages under an `exceptions` block in `en.json`.
- `reconfiguration-flow` — added `async_step_reconfigure` so the host/username can be updated without re-adding the integration, with a `wrong_device` abort if the new address points to a different serial number.
- `entity-category` — `WiserSystemFlag` now uses `EntityCategory.CONFIG`.
- `stale-devices` (partial) — orphaned device registry entries are removed on setup when they no longer exist on the gateway. See "Known limitations" below.

**Platinum tier:**
- `strict-typing` (partial) — added a mypy step to CI and fixed type errors across the integration. See "Known limitations" below.

## Other changes
- Bumped the `websockets` requirement to a minimum supported version (`websockets>=13.0`). This is a compatibility floor, not related to the `dependency-transparency` rule (which concerns dependency provenance, not version bounds).
- Fixed `_attr_supported_color_modes` to be a `set` instead of a `list` (Home Assistant expects a set).
- Corrected the `climate.py` module docstring and scoped `lint.sh`/mypy to `custom_components` and `tests`.

## Known limitations / follow-ups
- **`stale-devices`** is implemented as a one-shot cleanup during `async_setup_entry` using `device_registry.async_remove_device`. The rule's documented pattern is to track devices in the coordinator and call `async_update_device(remove_config_entry_id=...)`, and/or implement `async_remove_config_entry_device` for a manual delete button. Consequences of the current approach: devices removed from the gateway while HA is running are not pruned until the next reload/restart, and the device is removed outright rather than only detached from this config entry. Consider migrating to the coordinator-tracked approach.
- **`strict-typing`** uses a basic mypy configuration (`ignore_missing_imports = true`) without the strict flags (`disallow_untyped_defs`, etc.) or a `py.typed` marker. This catches obvious type errors but does not yet meet the full Platinum strict-typing bar.
- **`action-exceptions`** — `status_light_failed` (raised on a gateway/network error) currently uses `ServiceValidationError`; per the rule, operational/network failures should be `HomeAssistantError` while `ServiceValidationError` is reserved for invalid user input.

## Still open

**Bronze:**
- `dependency-transparency` — verify `websockets`/`aiowiserbyfeller` meet the provenance criteria (OSI license, PyPI, public CI build, tagged release).
- `docs-actions`, `docs-high-level-description`, `docs-installation-instructions`, `docs-removal-instructions` — README gaps.

**Gold:**
- `dynamic-devices` — devices added to the gateway while HA is running are not picked up without a restart.
- `entity-translations` — load entities rely on platform class names rather than explicit translation keys.
- `docs-data-update`, `docs-examples`, `docs-known-limitations`, `docs-supported-devices`, `docs-supported-functions`, `docs-troubleshooting`, `docs-use-cases` — README gaps.

**Platinum:**
- ~~`inject-websession` — waiting for `aiowiserbyfeller` support~~ → Decided against implementing this.
